### PR TITLE
[IMPORT] handle TOC variances

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 helix-importer-ui
+tools/

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -254,14 +254,21 @@ export default {
     }
     // create the metadata block and append it to the main element
 
-    const container = document.querySelector('.container-article');
+    const container = document.querySelector('.container-article, .rates-fees');
     if (container) {
-      container.after(document.createElement('hr'));
-    }
+      const template = document.querySelector('meta[name="template"]');
 
-    const ratesFees = document.querySelector('.rates-fees');
-    if (ratesFees) {
-      ratesFees.after(document.createElement('hr'));
+      let layoutType = 'article-short';
+      if (template?.content === 'help-centre-long-article-template') {
+        layoutType = 'article-long';
+      }
+
+      container.after(document.createElement('hr'));
+
+      container.after(WebImporter.DOMUtils.createTable([
+        ['section-metadata'],
+        ['style', layoutType],
+      ], document));
     }
 
     const cells = [


### PR DESCRIPTION
Enforce adding a section-metadata block for `.container-article` and `.rates-fees` pages, with a `short`/`long` variance based on the presence of meta tag `template` === `help-centre-long-article-template`