### PR TITLE
feat: add table of contents autoblock

### DIFF
--- a/help/blocks/hero/hero.css
+++ b/help/blocks/hero/hero.css
@@ -18,6 +18,7 @@ main .section.hero-container:has(.hero-img-right) {
 
 main .hero-container .hero-wrapper {
   max-width: 2080px;
+  margin: auto;
 }
 
 main .hero {

--- a/help/blocks/toc/toc.css
+++ b/help/blocks/toc/toc.css
@@ -2,7 +2,7 @@ html {
   scroll-behavior: smooth;
 }
 
-.section.long-article .article-main-wrapper {
+.section.article-long .article-main-wrapper {
   display: flex;
 }
 

--- a/help/blocks/toc/toc.css
+++ b/help/blocks/toc/toc.css
@@ -1,0 +1,62 @@
+html {
+  scroll-behavior: smooth;
+}
+
+.section.long-article .article-main-wrapper {
+  display: flex;
+}
+
+.toc.block {
+  display: none;
+}
+
+.toc-content-wrapper {
+  --toc-link-color: #0c6cce;
+  --toc-link-background-color: #f5f5f5;
+}
+
+@media (min-width: 600px) {
+  .toc.block {
+    display: flex;
+    align-self: flex-start;
+    flex: 1;
+    position: sticky;
+    top: 48px;
+    padding-right: 40px;
+    line-height: 1.75rem;
+  }
+
+  .toc-content-wrapper a {
+    display: block;
+    flex-flow: row;
+    align-items: stretch;
+    box-sizing: border-box;
+    padding: 16px 0 16px 24px;
+  }
+
+  .toc-content-wrapper a:hover {
+    background-color: var(--toc-link-background-color);
+    text-decoration: none;
+  }
+
+  .toc-content-wrapper a.active {
+    border-left: 4px solid var(--toc-link-color);
+    color: var(--toc-link-color);
+    font-weight: 700;
+    padding-left: 20px;
+  }
+
+  .toc-content-wrapper a.active:hover {
+    background-color: inherit;
+  }
+
+  .article-content-wrapper {
+    flex: 2;
+    border-left: 1px solid #ccc;
+    padding-left: 40px;
+  }
+
+  .scroll-margin {
+    scroll-margin-top: 10px;
+  }
+}

--- a/help/blocks/toc/toc.css
+++ b/help/blocks/toc/toc.css
@@ -10,12 +10,6 @@ html {
   display: none;
 }
 
-.toc-content-wrapper {
-  --toc-link-color: #0c6cce;
-  --toc-secondary-link-color: #7f7f7f;;
-  --toc-link-background-color: #f5f5f5;
-}
-
 @media (min-width: 600px) {
   .toc.block {
     display: flex;

--- a/help/blocks/toc/toc.css
+++ b/help/blocks/toc/toc.css
@@ -67,7 +67,6 @@ html {
     padding-left: 20px;
   }
 
-
   .toc-content-wrapper li.second-level {
     padding-left: 16px;
   }
@@ -99,6 +98,6 @@ html {
   }
 
   .scroll-margin {
-    scroll-margin-top: 10px;
+    scroll-margin-top: 20px;
   }
 }

--- a/help/blocks/toc/toc.css
+++ b/help/blocks/toc/toc.css
@@ -32,6 +32,7 @@ html {
     align-items: stretch;
     box-sizing: border-box;
     padding: 16px 0 16px 24px;
+    text-decoration: none;
   }
 
   .toc-content-wrapper a:hover {

--- a/help/blocks/toc/toc.css
+++ b/help/blocks/toc/toc.css
@@ -12,6 +12,7 @@ html {
 
 .toc-content-wrapper {
   --toc-link-color: #0c6cce;
+  --toc-secondary-link-color: #7f7f7f;;
   --toc-link-background-color: #f5f5f5;
 }
 
@@ -26,6 +27,12 @@ html {
     line-height: 1.75rem;
   }
 
+  .toc-content-wrapper ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+
   .toc-content-wrapper a {
     display: block;
     flex-flow: row;
@@ -38,17 +45,51 @@ html {
   .toc-content-wrapper a:hover {
     background-color: var(--toc-link-background-color);
     text-decoration: none;
+    color: inherit;
   }
 
-  .toc-content-wrapper a.active {
+  .toc-content-wrapper a.active:hover {
+    background-color: inherit;
+  }
+
+  .toc-content-wrapper li.first-level {
+    box-sizing: border-box;
+    border-left: 4px solid transparent;
+  }
+
+  .toc-content-wrapper li.first-level:has(a.active) {
     border-left: 4px solid var(--toc-link-color);
+  }
+
+  .toc-content-wrapper li.first-level > a.active {
     color: var(--toc-link-color);
     font-weight: 700;
     padding-left: 20px;
   }
 
-  .toc-content-wrapper a.active:hover {
-    background-color: inherit;
+
+  .toc-content-wrapper li.second-level {
+    padding-left: 16px;
+  }
+
+  .toc-content-wrapper li.second-level a {
+    color: var(--toc-secondary-link-color);
+  }
+
+  .toc-content-wrapper li.second-level a:hover {
+    color: inherit;
+  }
+
+  .toc-content-wrapper li.second-level a.active {
+    color: var(--toc-link-color);
+  }
+
+  .toc-content-wrapper li.first-level:has(li.second-level a.active) {
+    border-left: 4px solid var(--toc-link-color);
+  }
+
+  .toc-content-wrapper li.first-level:has(li.second-level a.active) > a {
+    font-weight: 700;
   }
 
   .article-content-wrapper {

--- a/help/blocks/toc/toc.js
+++ b/help/blocks/toc/toc.js
@@ -32,19 +32,62 @@ function createAnchorTagLink(tocContentWrapper, hTag) {
   });
 }
 
+function getOrCreateTag(container, tagName) {
+  const existingTag = container.querySelector(tagName);
+  if (existingTag) {
+    return existingTag;
+  }
+  const newTag = document.createElement(tagName);
+  container.append(newTag);
+  return newTag;
+}
+
+function createNestedAnchorTagLinks(content, toc) {
+  const headings = content.querySelectorAll('h2, h3');
+  const nestedList = document.createElement('ul');
+  toc.append(nestedList);
+  let lastTopLi = null;
+
+  headings.forEach((heading) => {
+    const tagName = heading.tagName.toLowerCase();
+    if (tagName === 'h2') {
+      const li = document.createElement('li');
+      li.setAttribute('class', 'first-level');
+      nestedList.append(li);
+      createAnchorTagLink(li, heading);
+      lastTopLi = li;
+    } else if (tagName === 'h3') {
+      // handle articles starting directly with H3
+      if (!lastTopLi) {
+        const topLi = document.createElement('li');
+        topLi.setAttribute('class', 'first-level');
+        nestedList.append(topLi);
+        lastTopLi = topLi;
+      }
+
+      const li = document.createElement('li');
+      li.setAttribute('class', 'second-level');
+      const ul = getOrCreateTag(lastTopLi, 'ul');
+      ul.append(li);
+      createAnchorTagLink(li, heading);
+    }
+  });
+}
+
 export default function decorate(block) {
   const articleContent = document.querySelector('.article-long');
   if (!articleContent) {
     return; // no ToC if it's not a long article
   }
 
+  // move article content into a wrapper
   const contentDivs = articleContent.querySelectorAll(':scope > div');
-
   const articleContentWrapper = createTag('div', { class: 'article-content-wrapper' });
   contentDivs.forEach((div) => {
     articleContentWrapper.append(div);
   });
 
+  // article-main-wrapper contains two wrappers: ToC and content
   const articleMainWrapper = createTag('div', { class: 'article-main-wrapper' });
   articleMainWrapper.append(block);
   articleMainWrapper.append(articleContentWrapper);
@@ -55,10 +98,7 @@ export default function decorate(block) {
   block.textContent = '';
   block.append(tocContentWrapper);
 
-  const headerTags = articleContentWrapper.querySelectorAll('h2, h3');
-  headerTags.forEach((headerTag) => {
-    createAnchorTagLink(tocContentWrapper, headerTag);
-  });
+  createNestedAnchorTagLinks(articleContentWrapper, tocContentWrapper);
 
   // clean up the old div
   const main = document.querySelector('main');

--- a/help/blocks/toc/toc.js
+++ b/help/blocks/toc/toc.js
@@ -8,7 +8,7 @@ function createAnchorTagLink(tocContentWrapper, hTag) {
   const tagName = hTag.tagName.toLowerCase();
 
   // create link element
-  const aLink = createTag('a', { class: 'content-link', href: `#${contentLinkId}`});
+  const aLink = createTag('a', { class: 'content-link', href: `#${contentLinkId}` });
   aLink.append(contentLink);
   aLink.classList.add(tagName);
   tocContentWrapper.append(aLink);

--- a/help/blocks/toc/toc.js
+++ b/help/blocks/toc/toc.js
@@ -1,0 +1,67 @@
+import { createTag } from '../../scripts/lib-franklin.js';
+
+const sections = [];
+
+function createAnchorTagLink(tocContentWrapper, hTag) {
+  const contentLinkId = hTag.getAttribute('id');
+  const contentLink = hTag.textContent;
+  const tagName = hTag.tagName.toLowerCase();
+
+  // create link element
+  const aLink = createTag('a', { class: 'content-link', href: `#${contentLinkId}`});
+  aLink.append(contentLink);
+  aLink.classList.add(tagName);
+  tocContentWrapper.append(aLink);
+
+  // add scroll listener to calculate the active link
+  document.getElementsByClassName('content-link')[0].classList.add('active');
+  document.getElementById(contentLinkId).classList.add('scroll-margin');
+  sections.push(document.getElementById(contentLinkId));
+  window.addEventListener('scroll', () => {
+    const scrollAmount = window.scrollY;
+    sections.forEach((element) => {
+      if (scrollAmount >= ((element.offsetTop) - 130)) {
+        const idName = element.getAttribute('id');
+        if (idName === contentLinkId) {
+          aLink.classList.add('active');
+        } else {
+          aLink.classList.remove('active');
+        }
+      }
+    });
+  });
+}
+
+export default function decorate(block) {
+  const articleContent = document.querySelector('.long-article');
+  if (!articleContent) {
+    return; // no ToC if it's not a long article
+  }
+
+  const contentDivs = articleContent.querySelectorAll(':scope > div');
+
+  const articleContentWrapper = createTag('div', { class: 'article-content-wrapper' });
+  contentDivs.forEach((div) => {
+    articleContentWrapper.append(div);
+  });
+
+  const articleMainWrapper = createTag('div', { class: 'article-main-wrapper' });
+  articleMainWrapper.append(block);
+  articleMainWrapper.append(articleContentWrapper);
+  articleContent.textContent = '';
+  articleContent.append(articleMainWrapper);
+
+  const tocContentWrapper = createTag('div', { class: 'toc-content-wrapper' });
+  block.textContent = '';
+  block.append(tocContentWrapper);
+
+  const headerTags = articleContentWrapper.querySelectorAll('h3, h4');
+  headerTags.forEach((headerTag) => {
+    createAnchorTagLink(tocContentWrapper, headerTag);
+  });
+
+  // clean up the old div
+  const main = document.querySelector('main');
+  const tocContainer = main.querySelector('.section.toc-container');
+  main.removeChild(tocContainer);
+}

--- a/help/blocks/toc/toc.js
+++ b/help/blocks/toc/toc.js
@@ -33,7 +33,7 @@ function createAnchorTagLink(tocContentWrapper, hTag) {
 }
 
 export default function decorate(block) {
-  const articleContent = document.querySelector('.long-article');
+  const articleContent = document.querySelector('.article-long');
   if (!articleContent) {
     return; // no ToC if it's not a long article
   }
@@ -55,7 +55,7 @@ export default function decorate(block) {
   block.textContent = '';
   block.append(tocContentWrapper);
 
-  const headerTags = articleContentWrapper.querySelectorAll('h3, h4');
+  const headerTags = articleContentWrapper.querySelectorAll('h2, h3');
   headerTags.forEach((headerTag) => {
     createAnchorTagLink(tocContentWrapper, headerTag);
   });

--- a/help/scripts/scripts.js
+++ b/help/scripts/scripts.js
@@ -11,11 +11,25 @@ import {
   waitForLCP,
   loadBlocks,
   loadCSS,
+  readBlockConfig,
 } from './lib-franklin.js';
 
 const LCP_BLOCKS = ['hero']; // add your LCP blocks to the list
 
 window.hlx.codeBasePath = '/help';
+
+/**
+ * Extracts section metadata (for all sections) from a container element.
+ * @param {Element} main The container element
+ * @returns {Array} An array of section metadata objects
+ */
+function getSectionMetadata(main) {
+  const allSectionMeta = main.querySelectorAll('div.section-metadata');
+  return [...allSectionMeta].map((sectionMeta) => {
+    const meta = readBlockConfig(sectionMeta);
+    return meta;
+  });
+}
 
 /**
  * Builds hero block and prepends to main in a new section.
@@ -58,6 +72,21 @@ function buildHeroBlock(main) {
 }
 
 /**
+ *  Auto block Table of Contents for long-article sections
+ */
+function buildTocBlock(main) {
+  // check that the main has a 'long-article' section
+  const sectionMeta = getSectionMetadata(main);
+  if (sectionMeta.filter((meta) => meta.style === 'long-article').length > 0) {
+    const section = document.createElement('div');
+    section.append(buildBlock('toc', {
+      elems: [],
+    }));
+    main.prepend(section);
+  }
+}
+
+/**
  * load fonts.css and set a session storage flag
  */
 async function loadFonts() {
@@ -76,6 +105,7 @@ async function loadFonts() {
 function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
+    buildTocBlock(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/help/scripts/scripts.js
+++ b/help/scripts/scripts.js
@@ -72,12 +72,12 @@ function buildHeroBlock(main) {
 }
 
 /**
- *  Auto block Table of Contents for long-article sections
+ *  Auto block Table of Contents for article-long sections
  */
 function buildTocBlock(main) {
-  // check that the main has a 'long-article' section
+  // check that the main has an 'article-long' section
   const sectionMeta = getSectionMetadata(main);
-  if (sectionMeta.filter((meta) => meta.style === 'long-article').length > 0) {
+  if (sectionMeta.filter((meta) => meta.style === 'article-long').length > 0) {
     const section = document.createElement('div');
     section.append(buildBlock('toc', {
       elems: [],

--- a/help/styles/styles.css
+++ b/help/styles/styles.css
@@ -20,6 +20,9 @@
   --button-color: #0c6cce;
   --button-hover-color: #0458ad;
   --columns-border: #f7f7f7;
+  --toc-link-color: #0c6cce;
+  --toc-secondary-link-color: #7f7f7f;;
+  --toc-link-background-color: #f5f5f5;
 
   /* search */
   --search-text-color: #333;


### PR DESCRIPTION
Table of Contents auto-blocking implementation and styling. Relies on ~style: long-article~ `style: article-long` section metadata.

~Doesn't~  Updated to style the nested h4.

Fixes #24 #25 

Test URLs:

### Simple ToC (H2 only)
- Before: https://main--macquarie-help-centre--hlxsites.hlx.page/help/personal/accessing-online-and-mobile-banking/customise-your-online-banking/customise-browser-notifications
- After: https://toc--macquarie-help-centre--hlxsites.hlx.page/help/personal/accessing-online-and-mobile-banking/customise-your-online-banking/customise-browser-notifications

### Nested ToC (H2 and H3)
- Before: https://main--macquarie-help-centre--hlxsites.hlx.page/help/personal/accessing-online-and-mobile-banking/customise-your-online-banking/customise-your-insights-page
- After: https://toc--macquarie-help-centre--hlxsites.hlx.page/help/personal/accessing-online-and-mobile-banking/customise-your-online-banking/customise-your-insights-page

### No ToC
- Before: https://main--macquarie-help-centre--hlxsites.hlx.page/help/personal/accessing-online-and-mobile-banking/macquarie-authenticator-and-multi-factor-authentication/rolling-codes-for-macquarie-authenticator
- After: https://toc--macquarie-help-centre--hlxsites.hlx.page/help/personal/accessing-online-and-mobile-banking/macquarie-authenticator-and-multi-factor-authentication/rolling-codes-for-macquarie-authenticator