### PR TITLE
Decorate gplay/itunes svgs to open in new tabs

### DIFF
--- a/help/scripts/scripts.js
+++ b/help/scripts/scripts.js
@@ -158,7 +158,7 @@ function decorateSvgIconImages(main) {
   const anchorElements = main.querySelectorAll('a');
 
   anchorElements.forEach((anchor) => {
-    if (anchor.getAttribute('href').includes('google') || anchor.getAttribute('href').includes('itunes')) {
+    if (anchor.getAttribute('href').includes('play.google.com') || anchor.getAttribute('href').includes('itunes')) {
       anchor.setAttribute('target', '_blank');
       const parentParagraph = anchor.parentElement;
       if (parentParagraph && parentParagraph.tagName === 'P') {

--- a/help/scripts/scripts.js
+++ b/help/scripts/scripts.js
@@ -112,9 +112,11 @@ function decorateExternalLinks(main) {
     const isPdfLink = href.includes('pdf');
     const phone = href.includes('tel');
     const mail = href.includes('mailto');
+    const itunes = href.includes('itunes');
+    const gplay = href.includes('google');
 
     if (!isPdfLink && !isLinkInTableCell(a) && !href.startsWith('/')
-      && !href.startsWith('#') && !phone && !mail) {
+      && !href.startsWith('#') && !phone && !mail && !itunes && !gplay) {
       // Set the 'target' attribute to '_blank'
       a.setAttribute('target', '_blank');
 
@@ -151,6 +153,21 @@ function decoratePdfLinks(main) {
   });
 }
 
+function decorateSvgIconImages(main) {
+  const anchorElements = main.querySelectorAll('a');
+
+  anchorElements.forEach((anchor) => {
+    if (anchor.getAttribute('href').includes('google') || anchor.getAttribute('href').includes('itunes')) {
+      anchor.setAttribute('target', '_blank');
+      const parentParagraph = anchor.parentElement;
+      if (parentParagraph && parentParagraph.tagName === 'P') {
+        parentParagraph.classList.add('svg');
+        anchor.classList.add('icon-link');
+      }
+    }
+  });
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -165,6 +182,7 @@ export function decorateMain(main) {
   decorateBlocks(main);
   decorateExternalLinks(main);
   decoratePdfLinks(main);
+  decorateSvgIconImages(main);
 }
 
 /**

--- a/help/scripts/scripts.js
+++ b/help/scripts/scripts.js
@@ -109,6 +109,7 @@ function isPartOfContinuousLine(linkElement) {
 function decorateExternalLinks(main) {
   main.querySelectorAll('a').forEach((a) => {
     const href = a.getAttribute('href');
+    const title = a.getAttribute('title');
     const isPdfLink = href.includes('pdf');
     const phone = href.includes('tel');
     const mail = href.includes('mailto');
@@ -116,7 +117,7 @@ function decorateExternalLinks(main) {
     const gplay = href.includes('google');
 
     if (!isPdfLink && !isLinkInTableCell(a) && !href.startsWith('/')
-      && !href.startsWith('#') && !phone && !mail && !itunes && !gplay) {
+      && !href.startsWith('#') && !phone && !mail && !itunes && !gplay && title === 'Quick exit') {
       // Set the 'target' attribute to '_blank'
       a.setAttribute('target', '_blank');
 

--- a/help/styles/styles.css
+++ b/help/styles/styles.css
@@ -387,14 +387,11 @@ main .section:empty {
   content: url("../icons/download-icon-blue.svg");
 }
 
-.icon.icon-google-play-icon svg {
-  width: 120px;
-  height: 50px;
-}
-
+.icon.icon-google-play-icon svg,
 .icon.icon-app-store-logo svg {
   width: 120px;
   height: 40px;
+  pointer-events: auto;
 }
 
 .icon-link {
@@ -417,4 +414,5 @@ main .section:empty {
 
 .svg a {
   display: block;
+  pointer-events: none;
 }

--- a/help/styles/styles.css
+++ b/help/styles/styles.css
@@ -387,3 +387,34 @@ main .section:empty {
   content: url("../icons/download-icon-blue.svg");
 }
 
+.icon.icon-google-play-icon svg {
+  width: 120px;
+  height: 50px;
+}
+
+.icon.icon-app-store-logo svg {
+  width: 120px;
+  height: 40px;
+}
+
+.icon-link {
+  position: relative;
+}
+
+.icon-link::after {
+  content: url('../icons/icon-external-link.svg');
+  width: 20px;
+  height: 20px;
+  position: absolute;
+  top: 53%;
+  left: 125px;
+  transform: translateY(-50%);
+}
+
+.icon-link:hover::after {
+  content: url('../icons/icon-external-link-blue.svg');
+}
+
+.svg a {
+  display: block;
+}


### PR DESCRIPTION
Fix #33 

Test URLs:
- Before: https://main--macquarie-help-centre--hlxsites.hlx.page/help/drafts/asthabharga/bulk_import/help/personal/accessing-online-and-mobile-banking/macquarie-authenticator-and-multi-factor-authentication/set-up-macquarie-authenticator
- After: https://issue-33--macquarie-help-centre--hlxsites.hlx.page/help/drafts/asthabharga/bulk_import/help/personal/accessing-online-and-mobile-banking/macquarie-authenticator-and-multi-factor-authentication/set-up-macquarie-authenticator

original site link:
https://www.macquarie.com.au/help/personal/accessing-online-and-mobile-banking/macquarie-authenticator-and-multi-factor-authentication/set-up-macquarie-authenticator.html (I have kept both svgs uniform for better experience)

Note: Quick exit button styling to be picked up in separate issue
https://github.com/hlxsites/macquarie-help-centre/issues/51
https://issue-33--macquarie-help-centre--hlxsites.hlx.page/help/drafts/asthabharga/bulk_import/help/personal/account-info-and-profile/financial-assistance/financial-abuse-support