### PR TITLE
fix: [firefox] remove usage of :has in ToC

### DIFF
--- a/help/blocks/toc/toc.css
+++ b/help/blocks/toc/toc.css
@@ -51,14 +51,13 @@ html {
     border-left: 4px solid transparent;
   }
 
-  .toc-content-wrapper li.first-level:has(a.active) {
+  .toc-content-wrapper li.first-level.active {
     border-left: 4px solid var(--toc-link-color);
   }
 
   .toc-content-wrapper li.first-level > a.active {
     color: var(--toc-link-color);
     font-weight: 700;
-    padding-left: 20px;
   }
 
   .toc-content-wrapper li.second-level {
@@ -69,20 +68,16 @@ html {
     color: var(--toc-secondary-link-color);
   }
 
+  .toc-content-wrapper li.first-level.active > a {
+    font-weight: 700;
+  }
+
   .toc-content-wrapper li.second-level a:hover {
     color: inherit;
   }
 
   .toc-content-wrapper li.second-level a.active {
     color: var(--toc-link-color);
-  }
-
-  .toc-content-wrapper li.first-level:has(li.second-level a.active) {
-    border-left: 4px solid var(--toc-link-color);
-  }
-
-  .toc-content-wrapper li.first-level:has(li.second-level a.active) > a {
-    font-weight: 700;
   }
 
   .article-content-wrapper {

--- a/help/blocks/toc/toc.js
+++ b/help/blocks/toc/toc.js
@@ -15,8 +15,11 @@ function createAnchorTagLink(tocContentWrapper, hTag) {
 
   // add scroll listener to calculate the active link
   document.getElementsByClassName('content-link')[0].classList.add('active');
+  document.getElementsByClassName('content-link')[0].closest('.first-level')?.classList.add('active');
+
   document.getElementById(contentLinkId).classList.add('scroll-margin');
   sections.push(document.getElementById(contentLinkId));
+
   window.addEventListener('scroll', () => {
     const scrollAmount = window.scrollY;
     sections.forEach((element) => {
@@ -24,8 +27,17 @@ function createAnchorTagLink(tocContentWrapper, hTag) {
         const idName = element.getAttribute('id');
         if (idName === contentLinkId) {
           aLink.classList.add('active');
+          tocContentWrapper.classList.add('active');
+          tocContentWrapper.closest('.first-level')?.classList.add('active');
         } else {
           aLink.classList.remove('active');
+          tocContentWrapper.classList.remove('active');
+
+          // remove active class from parent only if no child is active
+          const firstLevelParent = tocContentWrapper.closest('.first-level');
+          if (firstLevelParent && !firstLevelParent.querySelector('.active')) {
+            tocContentWrapper.closest('.first-level')?.classList.remove('active');
+          }
         }
       }
     });


### PR DESCRIPTION
The js is updated to add additional classes on the parent `li` to compensate for the usage of `:has`.

Test URLs:
- Before: https://main--macquarie-help-centre--hlxsites.hlx.page/help/personal/home-loans/set-up-your-home-loan/home-loan-settlement#before-settlement-day
- After: https://fix-has-toc--macquarie-help-centre--hlxsites.hlx.page/help/personal/home-loans/set-up-your-home-loan/home-loan-settlement#before-settlement-day
